### PR TITLE
Implement `Last-Event-ID` behaviour and skip empty log messages

### DIFF
--- a/src/main/scala/io/hydrosphere/serving/manager/api/http/controller/events/SSEController.scala
+++ b/src/main/scala/io/hydrosphere/serving/manager/api/http/controller/events/SSEController.scala
@@ -19,7 +19,6 @@ import streamz.converter._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.Try
 
 class SSEController[F[_]](
   applicationSubscriber: ApplicationSubscriber[F],

--- a/src/main/scala/io/hydrosphere/serving/manager/api/http/controller/events/SSEController.scala
+++ b/src/main/scala/io/hydrosphere/serving/manager/api/http/controller/events/SSEController.scala
@@ -19,6 +19,7 @@ import streamz.converter._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.util.Try
 
 class SSEController[F[_]](
   applicationSubscriber: ApplicationSubscriber[F],

--- a/src/main/scala/io/hydrosphere/serving/manager/domain/model_build/LogSink.scala
+++ b/src/main/scala/io/hydrosphere/serving/manager/domain/model_build/LogSink.scala
@@ -82,11 +82,15 @@ object DockerLogger {
     new ProgressHandler {
 
       override def progress(message: ProgressMessage): Unit = {
-        val msg = Option(message.error())
+        val maybeMsg = Option(message.error())
           .orElse(Option(message.stream()))
           .orElse(Option(message.status()))
-          .getOrElse("")
-        topic.publish1(msg).toIO.unsafeRunSync()
+        maybeMsg.foreach { msg =>
+          val trimmed = msg.trim
+          if (trimmed.nonEmpty) {
+            topic.publish1(trimmed).toIO.unsafeRunSync()
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
https://www.html5rocks.com/en/tutorials/eventsource/basics/
> Setting an ID lets the browser keep track of the last event fired so that if, the connection to the server is dropped, a special HTTP header (Last-Event-ID) is set with the new request. This lets the browser determine which event is appropriate to fire. The message event contains a e.lastEventId property.