### PR TITLE
build: upgrade packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,10 @@ dockerfile in docker := {
     label("maintainer", "support@hydrosphere.io")
 
     run("apk", "update")
-    run("apk", "add", "libcrypto1.1>=1.1.1", "libssl1.1>=1.1.1", "openssl>=1.1.1", "jq")
+    run("apk", "add", "--no-cache", "freetype>=2.9.1-r3", "krb5-libs>=1.15.5-r1", "libbz2>=1.0.6-r7", 
+        "libcom_err>=1.44.5-r2", "libcrypto1.1>=1.1.1k-r0", "libjpeg-turbo>=1.5.3-r6", "libssl1.1>=1.1.1k-r0", 
+        "libtasn1>=4.14", "libx11>=1.6.12-r0", "musl>=1.1.20-r6", "openjdk8-jre>=8.272.10-r0", 
+        "openjdk8-jre-base>=8.272.10-r0", "openjdk8-jre-lib>=8.272.10-r0", "sqlite-libs>=3.28.0-r3", "jq")
     run("rm", "-rf", "/var/cache/apk/*")
 
     workDir("/app/")


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:

https://snyk.io/vuln/SNYK-ALPINE39-BZIP2-452847
https://snyk.io/vuln/SNYK-ALPINE39-MUSL-458529
https://snyk.io/vuln/SNYK-ALPINE39-SQLITE-449671
https://snyk.io/vuln/SNYK-ALPINE39-KRB5-1045189
https://snyk.io/vuln/SNYK-ALPINE39-LIBJPEGTURBO-588623
https://snyk.io/vuln/SNYK-ALPINE39-LIBX11-608581
https://snyk.io/vuln/SNYK-ALPINE39-OPENJDK8-597930
https://snyk.io/vuln/SNYK-ALPINE39-OPENJDK8-597929
https://snyk.io/vuln/SNYK-ALPINE39-OPENJDK8-588981
https://snyk.io/vuln/SNYK-ALPINE39-OPENJDK8-1075705
https://snyk.io/vuln/SNYK-ALPINE39-OPENJDK8-1075704
https://snyk.io/vuln/SNYK-ALPINE39-OPENSSL-588029
https://snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089235
https://snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089232
https://snyk.io/vuln/SNYK-ALPINE39-SQLITE-587441
https://snyk.io/vuln/SNYK-ALPINE39-SQLITE-449762
https://snyk.io/vuln/SNYK-ALPINE39-SQLITE-1019958
and other 60 vulnerabilities